### PR TITLE
Ensures Market Hash Fragment Checked on New Listing

### DIFF
--- a/float.js
+++ b/float.js
@@ -577,11 +577,10 @@ const addInventoryBoxes = async function() {
 // If an item on the current page doesn't have the float div/buttons, this function adds it
 const addMarketButtons = async function() {
     // Iterate through each item on the page
-    let listingRows = document.querySelectorAll('#searchResultsRows .market_listing_row.market_recent_listing_row');
+    let listingRows = document.querySelectorAll('.market_listing_row.market_recent_listing_row');
 
     for (let row of listingRows) {
-        let id = row.id.replace('listing_', '');
-
+        let id = row.id.replace('listing_', '').replace('Copy', '');
         const steamListingData = await retrieveListingInfoFromPage(id);
         const listingData = steamListingData[id];
 
@@ -591,11 +590,18 @@ const addMarketButtons = async function() {
             continue;
         }
 
+        // Check if a 'buylisting' hash fragment can now be matched
+        checkMarketHash();
+
         const inspectLink = listingData.asset.market_actions[0].link
             .replace('%listingid%', id)
             .replace('%assetid%', listingData.asset.id);
 
         let listingNameElement = row.querySelector(`#listing_${id}_name`);
+        if (!listingNameElement) {
+            // Handle instances where it's a buy dialog opening
+            listingNameElement = row.querySelector(`#listing_${id}_nameCopy`);
+        }
 
         let floatDiv = document.createElement('div');
         floatDiv.classList.add('float-div');

--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -159,6 +159,15 @@ const retrieveTradeStatus = function() {
     });
 };
 
+const checkMarketHash = function() {
+    window.postMessage(
+        {
+            type: 'checkMarketHash'
+        },
+        '*'
+    );
+};
+
 // register the message listener in the page scope
 let script = document.createElement('script');
 script.innerText = `
@@ -245,6 +254,10 @@ script.innerText = `
                 type: 'tradeStatus',
                 tradeStatus: g_rgCurrentTradeStatus
             }, '*');
+        } else if (e.data.type == 'checkMarketHash') {
+            if (!BuyItemDialog.m_bInitialized) {
+                MarketCheckHash();
+            }
         }
     });
 `;


### PR DESCRIPTION
* Valve was lazy and made their fragment based buy dialog only work if the listing is on the front-page of the market, this change will do the check whenever a new market listing is loaded, so that the user will automatically have the buy dialog popup if they browse pages.

Example URL: https://steamcommunity.com/market/listings/730/P250%20%7C%20Hive%20(Field-Tested)#buylisting|2849038240193260592|730|2|18890559305